### PR TITLE
Fix Weaviate backend class

### DIFF
--- a/mem/weaviate.py
+++ b/mem/weaviate.py
@@ -1,9 +1,34 @@
 # mem/weaviate.py
-import os, weaviate, uuid, time, asyncio
+"""Simple Weaviate based memory backend."""
 
-_client = weaviate.Client(os.getenv("WEAVIATE_URL"))
+from __future__ import annotations
 
-async def write(event: dict):
-    event["id"] = uuid.uuid4().hex
-    event["timestamp"] = int(time.time())
-    _client.data_object.create(event, "MemoryEvent", uuid=event["id"])
+import os
+import uuid
+import time
+
+import weaviate
+
+
+class WeaviateMemory:
+    """Store events in a Weaviate collection."""
+
+    def __init__(self) -> None:
+        # Lazily initialise the client using the configured URL.  This mirrors
+        # the previous behaviour of a module level client but keeps it scoped to
+        # the class instance.
+        self._client = weaviate.Client(os.getenv("WEAVIATE_URL"))
+
+    async def write(self, event: dict) -> None:
+        """Add an event object to the ``MemoryEvent`` class."""
+
+        event["id"] = uuid.uuid4().hex
+        event["timestamp"] = int(time.time())
+        self._client.data_object.create(event, "MemoryEvent", uuid=event["id"])
+
+
+# Retain module level helper for backwards compatibility
+async def write(event: dict) -> None:
+    """Write using a default ``WeaviateMemory`` instance."""
+
+    await WeaviateMemory().write(event)


### PR DESCRIPTION
## Summary
- implement `WeaviateMemory` class for memory backend
- keep module level `write()` helper for backwards compatibility

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_683aad91cff0832b8f5736e5929ece50