### PR TITLE
Fix memory backend initialization

### DIFF
--- a/mem/__init__.py
+++ b/mem/__init__.py
@@ -1,16 +1,25 @@
 # mem/__init__.py
-import os, asyncio, json, time, importlib
+import asyncio
+import os
+
 
 class NullMemory:
-    async def write(self, event: dict): pass
+    async def write(self, event: dict):
+        pass
+
 
 def _load_backend():
     backend = os.getenv("MEM_BACKEND", "none").lower()
     if backend == "weaviate":
-        return importlib.import_module("mem.weaviate").WeaviateMemory()
+        from .weaviate import WeaviateMemory
+
+        return WeaviateMemory()
+
     return NullMemory()
 
+
 _memory = _load_backend()
+
 
 async def write(event: dict):
     # fire-and-forget so proxy latency is unaffected

--- a/tests/test_memory_init.py
+++ b/tests/test_memory_init.py
@@ -1,0 +1,25 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_init_weaviate_backend(monkeypatch):
+    """_load_backend() should instantiate WeaviateMemory when MEM_BACKEND=weaviate."""
+    monkeypatch.setenv("MEM_BACKEND", "weaviate")
+
+    class DummyMem:
+        def __init__(self):
+            self.created = True
+
+        async def write(self, event):
+            pass
+
+    dummy_mod = types.SimpleNamespace(WeaviateMemory=DummyMem)
+    monkeypatch.setitem(sys.modules, "mem.weaviate", dummy_mod)
+
+    mem = importlib.reload(importlib.import_module("mem"))
+
+    assert isinstance(mem._memory, DummyMem)


### PR DESCRIPTION
## Summary
- load Weaviate memory using the new class
- add a unit test verifying memory initialization when MEM_BACKEND=weaviate

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c9e95cbc4832bbde4668b56fd2413