### PR TITLE
Fix session header naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ curl -H "Authorization: Bearer $JWT" \
      http://localhost:8080/api/chat | jq .
 ```
 
-You should see a JSON response plus `X‑ATTACH‑Session‑Id` header – proof the pipeline works.
+You should see a JSON response plus `X‑Attach‑Session` header – proof the pipeline works.
 
 ---
 

--- a/middleware/session.py
+++ b/middleware/session.py
@@ -1,12 +1,19 @@
 # middleware/session.py
 from __future__ import annotations
-import hashlib, time, json
-from mem import write as mem_write
+
+import hashlib
+import json
+import time
+
 from fastapi import Request, Response
 from starlette.responses import JSONResponse
 
+from mem import write as mem_write
+
+
 def _session_id(sub: str, user_agent: str) -> str:
     return hashlib.sha256(f"{sub}:{user_agent}".encode()).hexdigest()
+
 
 async def session_mw(request: Request, call_next):
     # Defensive guard – if sub is missing return 401 instead of 500
@@ -14,8 +21,9 @@ async def session_mw(request: Request, call_next):
         return JSONResponse(status_code=401, content={"detail": "Unauthenticated"})
 
     sid = _session_id(request.state.sub, request.headers.get("user-agent", ""))
-    request.state.sid = sid             # expose to downstream handlers
+    request.state.sid = sid  # expose to downstream handlers
 
     response: Response = await call_next(request)
-    response.headers["X-UMP-Session-Id"] = sid[:16]  # expose *truncated* sid
+    # expose *truncated* session id
+    response.headers["X-Attach-Session"] = sid[:16]
     return response


### PR DESCRIPTION
## Summary
- rename `X-UMP-Session-Id` header to `X-Attach-Session`
- update README usage example to show final header name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c9eb08ae4832b849bf682cb9e2efd