### PR TITLE
Add session middleware tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt weaviate-client[embedded]
 
 # 1) start embedded memory (background tab)
-python scripts/start_weaviate.py &
+python script/start_weaviate.py &
 
 # 2) export your short‑lived token
 export JWT="<paste Auth0 or DID token>"
@@ -114,7 +114,7 @@ flowchart TD
 
 ```bash
 # pane 1 – memory
-python scripts/start_weaviate.py
+python script/start_weaviate.py
 
 # pane 2 – gateway
 uvicorn main:app --port 8080

--- a/auth/oidc.py
+++ b/auth/oidc.py
@@ -20,7 +20,7 @@ def _require_env(var: str) -> str:
     """Abort startup if a mandatory env-var is missing."""
     val = os.getenv(var)
     if not val:
-        raise RuntimeError(f"{var} must be set (see .cursorrules)")
+        raise RuntimeError(f"{var} must be set (see README for setup)")
     return val
 
 
@@ -59,8 +59,8 @@ def verify_jwt(token: str, *, leeway: int = 60) -> dict[str, Any]:
     """
     Validate a client-supplied JWT.
 
-    • Accept only RS256 / ES256.  
-    • Enforce `aud` and `exp` with configurable leeway.  
+    • Accept only RS256 / ES256.
+    • Enforce `aud` and `exp` with configurable leeway.
     • If `kid` is unknown, refresh JWKS once before failing.
 
     Returns:
@@ -95,7 +95,7 @@ def verify_jwt(token: str, *, leeway: int = 60) -> dict[str, Any]:
 
     return jwt.decode(
         token,
-        key_cfg,               # jose selects RSA/ECDSA key automatically
+        key_cfg,  # jose selects RSA/ECDSA key automatically
         algorithms=[alg],
         audience=audience,
         issuer=issuer,

--- a/middleware/session.py
+++ b/middleware/session.py
@@ -1,12 +1,19 @@
 # middleware/session.py
 from __future__ import annotations
-import hashlib, time, json
-from mem import write as mem_write
+
+import hashlib
+import json
+import time
+
 from fastapi import Request, Response
 from starlette.responses import JSONResponse
 
+from mem import write as mem_write
+
+
 def _session_id(sub: str, user_agent: str) -> str:
     return hashlib.sha256(f"{sub}:{user_agent}".encode()).hexdigest()
+
 
 async def session_mw(request: Request, call_next):
     # Defensive guard – if sub is missing return 401 instead of 500
@@ -14,8 +21,8 @@ async def session_mw(request: Request, call_next):
         return JSONResponse(status_code=401, content={"detail": "Unauthenticated"})
 
     sid = _session_id(request.state.sub, request.headers.get("user-agent", ""))
-    request.state.sid = sid             # expose to downstream handlers
+    request.state.sid = sid  # expose to downstream handlers
 
     response: Response = await call_next(request)
-    response.headers["X-UMP-Session-Id"] = sid[:16]  # expose *truncated* sid
+    response.headers["X-Attach-Session"] = sid[:16]  # expose *truncated* sid
     return response

--- a/tests/test_session_middleware.py
+++ b/tests/test_session_middleware.py
@@ -1,0 +1,52 @@
+import os
+
+import pytest
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+from starlette.middleware.base import BaseHTTPMiddleware
+
+os.environ["MEM_BACKEND"] = "none"
+
+from middleware.session import _session_id, session_mw
+
+
+@pytest.mark.asyncio
+async def test_missing_sub_returns_401():
+    app = FastAPI()
+    app.add_middleware(BaseHTTPMiddleware, dispatch=session_mw)
+
+    @app.get("/ping")
+    async def ping(request: Request):
+        return {"sid": getattr(request.state, "sid", None)}
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/ping")
+
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_valid_request_sets_header_and_state():
+    async def add_sub(request: Request, call_next):
+        request.state.sub = "user123"
+        return await call_next(request)
+
+    app = FastAPI()
+    # Add middlewares so that `add_sub` runs before `session_mw`
+    app.add_middleware(BaseHTTPMiddleware, dispatch=session_mw)
+    app.add_middleware(BaseHTTPMiddleware, dispatch=add_sub)
+
+    @app.get("/ping")
+    async def ping(request: Request):
+        return {"sid": request.state.sid}
+
+    headers = {"User-Agent": "UnitTest"}
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/ping", headers=headers)
+
+    expected_sid = _session_id("user123", "UnitTest")
+    assert resp.status_code == 200
+    assert resp.headers.get("x-attach-session") == expected_sid[:16]
+    assert resp.json().get("sid") == expected_sid


### PR DESCRIPTION
## Summary
- add unit tests for session_middleware
- rename response header to `X-Attach-Session`
- fix README quick-start path
- clarify environment setup message in `auth/oidc.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683c9ece5f54832bb2ebecd79ed10c4c