### PR TITLE
Add Sakana log ingestion endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ curl -X POST /v1/resource \
      -H "Authorization: Bearer did:key:z6Mki...<sig>.<payload>.<sig>"
 ```
 
+## 💾 Memory: logs
+
+Send Sakana-formatted logs to the gateway and they will be stored as
+`MemoryEvent` objects in Weaviate.
+
+```bash
+curl -X POST /v1/logs \
+     -H "Authorization: Bearer $JWT" \
+     -d '{"run_id":"abc","level":"info","message":"hi"}'
+# => HTTP/1.1 202 Accepted
+```
+
 ## Roadmap
 
 * **v0.2** — DID‑JWT resolver, protected‑resource metadata endpoint (OAuth 2.1).  

--- a/docs/Design.md
+++ b/docs/Design.md
@@ -48,7 +48,7 @@ flowchart LR
 1. **Auth** – verify JWT (OIDC) / HMAC.
 2. **Session** – `session_id = sha256(user.sub + user‑agent)`
 3. **Headers out** – `X-Attach-User`, `X-Attach-Session`, `X-Attach-Agent?`.
-4. **Mirror** – non‑blocking stream → memory stub.
+4. **Mirror** – non‑blocking stream → memory stub (also accepts `/v1/logs`).
 5. **Proxy** – reverse‑proxy to target engine.
 
 ---

--- a/logs.py
+++ b/logs.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import time
+from enum import Enum
+
+from fastapi import APIRouter, BackgroundTasks, Response, status
+from pydantic import BaseModel, Field
+
+from mem.sakana import write as sakana_write
+
+router = APIRouter()
+
+
+class LogLevel(str, Enum):
+    debug = "debug"
+    info = "info"
+    warn = "warn"
+    error = "error"
+    fatal = "fatal"
+
+
+class SakanaLog(BaseModel):
+    run_id: str
+    level: LogLevel
+    message: str
+    timestamp: float = Field(default_factory=lambda: time.time())
+    agent: str | None = None
+
+
+@router.post("/v1/logs", status_code=status.HTTP_202_ACCEPTED)
+async def ingest_log(event: SakanaLog, bg: BackgroundTasks) -> Response:
+    bg.add_task(sakana_write, event.model_dump(mode="json"))
+    return Response(status_code=status.HTTP_202_ACCEPTED)

--- a/main.py
+++ b/main.py
@@ -1,24 +1,26 @@
+import os
+
 from fastapi import FastAPI
 from fastapi.middleware import Middleware
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.middleware.base import BaseHTTPMiddleware
-from proxy.engine import proxy_to_engine
-from a2a.routes import router as a2a_router
-import os
 
-from middleware.auth import jwt_auth_mw         # ← your auth middleware
-from middleware.session import session_mw       # ← generates session-id header
+from a2a.routes import router as a2a_router
+from logs import router as logs_router
+from middleware.auth import jwt_auth_mw  # ← your auth middleware
+from middleware.session import session_mw  # ← generates session-id header
+from proxy.engine import proxy_to_engine
 
 middlewares = [
     # ❶ Auth first (executes first at request time)
     Middleware(BaseHTTPMiddleware, dispatch=jwt_auth_mw),
-
     # ❷ Session id second (executes after auth; sub is now available)
     Middleware(BaseHTTPMiddleware, dispatch=session_mw),
 ]
 
 app = FastAPI(title="attach-gateway", middleware=middlewares)
 app.include_router(a2a_router, prefix="/a2a")
+app.include_router(logs_router)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["http://localhost:9000"],
@@ -28,13 +30,15 @@ app.add_middleware(
 )
 
 # catch-all proxy (incl. /api/chat)
-app.add_api_route("/{path:path}", proxy_to_engine,
-                  methods=["GET", "POST", "PUT", "PATCH"])
+app.add_api_route(
+    "/{path:path}", proxy_to_engine, methods=["GET", "POST", "PUT", "PATCH"]
+)
+
 
 @app.get("/auth/config")
 async def auth_config():
     return {
         "domain": os.getenv("AUTH0_DOMAIN"),
         "client_id": os.getenv("AUTH0_CLIENT"),
-        "audience": os.getenv("OIDC_AUD")
+        "audience": os.getenv("OIDC_AUD"),
     }

--- a/mem/sakana.py
+++ b/mem/sakana.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from mem.weaviate import write as _weaviate_write
+
+
+async def write(event: dict) -> None:
+    """Persist a Sakana log event using the Weaviate memory backend."""
+    # TODO: buffer events and batch writes if log volume becomes high
+    await _weaviate_write(event)

--- a/tests/test_sakana_logs.py
+++ b/tests/test_sakana_logs.py
@@ -1,0 +1,75 @@
+import os
+import types
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+os.environ["MEM_BACKEND"] = "none"
+
+import logs
+import mem.sakana as sakana
+
+
+@pytest.fixture
+def app(monkeypatch):
+    app = FastAPI()
+    app.include_router(logs.router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_post_log_accepted(monkeypatch, app):
+    called = {}
+
+    async def fake_write(event):
+        called["event"] = event
+
+    monkeypatch.setattr(logs, "sakana_write", fake_write)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/v1/logs", json={"run_id": "r1", "level": "info", "message": "hi"}
+        )
+
+    assert resp.status_code == 202
+    assert called["event"]["run_id"] == "r1"
+    assert called["event"]["level"] == "info"
+    assert called["event"]["message"] == "hi"
+    assert isinstance(called["event"]["timestamp"], float)
+
+
+@pytest.mark.asyncio
+async def test_validation_error_returns_422(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/v1/logs", json={"level": "info", "message": "hi"})
+
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_integration_stores_in_weaviate(monkeypatch):
+    recorded = {}
+
+    class DummyClient:
+        def __init__(self, url):
+            self.data_object = types.SimpleNamespace(create=self.create)
+
+        def create(self, event, class_name, uuid=None):
+            recorded["event"] = event
+            recorded["class"] = class_name
+            recorded["uuid"] = uuid
+
+    import mem.weaviate as wv
+
+    monkeypatch.setattr(wv, "weaviate", types.SimpleNamespace(Client=DummyClient))
+
+    event = {"run_id": "123", "level": "info", "message": "test"}
+    await sakana.write(event)
+
+    assert recorded["class"] == "MemoryEvent"
+    assert "id" in recorded["event"]
+    assert "timestamp" in recorded["event"]
+    assert recorded["event"]["level"] == "info"


### PR DESCRIPTION
## Summary
- implement Sakana log adapter (`mem/sakana.py`)
- add `/v1/logs` route to accept Sakana logs
- store logs in Weaviate backend
- test log ingestion and validation
- document log endpoint in README
- refine log model with enum level and timestamp default
- mention log ingestion in design docs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683db8645324832bb6ce455402ab199d