### PR TITLE
Add Temporal adapter and workflow queue support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ LLM engines such as **Ollama** or **vLLM** ship with **zero auth**.  Agent‑to�
 *   ✅ Stamps `X‑ATTACH‑User` + `X‑ATTACH‑Session` headers so every downstream agent/tool sees the same identity
 *   ✅ Implements `/a2a/tasks/send` + `/tasks/status` for Google A2A & OpenHands hand‑off
 *   ✅ Mirrors prompts & responses to a memory backend (Weaviate embedded by default)
+*   ✅ Workflow traces (Temporal)
 
 Run it next to any model server and get secure, shareable context in under 1 minute.
 
@@ -44,7 +45,15 @@ uvicorn main:app --port 8080 &
 # 4) make a protected Ollama call via the gateway
 curl -H "Authorization: Bearer $JWT" \
      -d '{"model":"tinyllama","prompt":"hello"}' \
-     http://localhost:8080/api/chat | jq .
+    http://localhost:8080/api/chat | jq .
+```
+
+In another terminal, try the Temporal demo:
+
+```bash
+pip install temporalio  # optional workflow engine
+python examples/temporal_adapter/worker.py &
+python examples/temporal_adapter/client.py
 ```
 
 You should see a JSON response plus `X‑ATTACH‑Session‑Id` header – proof the pipeline works.

--- a/docs/Design.md
+++ b/docs/Design.md
@@ -95,8 +95,15 @@ export OLLAMA_TOKEN=$(./scripts/dev_login.sh)
 # Make a protected request via the gateway (8080)
 curl -H "Authorization: Bearer $OLLAMA_TOKEN" \
      -d '{"prompt":"Hello"}' \
-     http://localhost:8080/api/chat
+    http://localhost:8080/api/chat
 # Gateway ➜ validates JWT ➜ stamps X‑Attach‑User/Session ➜ proxies to Ollama :11434
+```
+
+### 5.4 Task queue schemes
+
+```
+http://<service>         # default HTTP call
+temporal://<Workflow>    # execute Temporal workflow
 ```
 
 ---

--- a/examples/temporal_adapter/client.py
+++ b/examples/temporal_adapter/client.py
@@ -1,0 +1,40 @@
+import asyncio
+import os
+
+import httpx
+
+JWT = os.environ["JWT"]
+GW_URL = os.getenv("GW_URL", "http://127.0.0.1:8080")
+
+
+async def main() -> None:
+    headers = {
+        "Authorization": f"Bearer {JWT}",
+        "X-Attach-Session": "temporal-demo",
+    }
+    payload = {
+        "input": {
+            "messages": [
+                {"role": "user", "content": "ping"},
+            ]
+        },
+        "target_url": "temporal://ProcessChat",
+    }
+    async with httpx.AsyncClient() as cli:
+        resp = await cli.post(f"{GW_URL}/a2a/tasks/send", json=payload, headers=headers)
+        resp.raise_for_status()
+        tid = resp.json()["task_id"]
+        while True:
+            r = await cli.get(
+                f"{GW_URL}/a2a/tasks/status/{tid}",
+                headers={"Authorization": f"Bearer {JWT}"},
+            )
+            data = r.json()
+            if data["state"] in {"done", "error"}:
+                print(data)
+                break
+            await asyncio.sleep(0.5)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/temporal_adapter/worker.py
+++ b/examples/temporal_adapter/worker.py
@@ -1,0 +1,32 @@
+import os
+from typing import Any
+
+from temporalio import workflow
+from temporalio.client import Client
+from temporalio.worker import Worker
+
+
+@workflow.defn
+class ProcessChat:
+    @workflow.run
+    async def run(self, messages: list[dict[str, Any]]) -> str:
+        tokens = sum(len(m.get("content", "").split()) for m in messages)
+        result = f"Processed {tokens} tokens"
+        return result
+
+
+async def main() -> None:
+    client = await Client.connect(os.getenv("TEMPORAL_URL", "localhost:7233"))
+    worker = Worker(
+        client,
+        task_queue=os.getenv("TEMPORAL_QUEUE", "attach-gateway"),
+        workflows=[ProcessChat],
+    )
+    print("Worker started. Waiting for tasks...")
+    await worker.run()
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,9 @@ weaviate-client>=4.4.0
 black>=24.1.0
 isort>=5.13.0
 
+# External Workflow Engine (Optional)
+temporalio>=1.5.0
+
 # LangChain Integration (Optional)
 langchain>=0.1.0
 langchain-core>=0.1.0

--- a/tests/test_temporal_queue.py
+++ b/tests/test_temporal_queue.py
@@ -1,0 +1,37 @@
+import asyncio
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from a2a.routes import _TASKS
+from a2a.routes import router as a2a_router
+
+pytest.importorskip("temporalio")
+
+
+@pytest.mark.asyncio
+async def test_temporal_scheme_triggers_workflow(monkeypatch):
+    async def fake_execute(target, payload, task_id):
+        assert target == "temporal://ProcessChat"
+        return "Processed 2 tokens"
+
+    monkeypatch.setattr("a2a.routes._execute_temporal", fake_execute)
+
+    app = FastAPI()
+    app.include_router(a2a_router, prefix="/a2a")
+
+    headers = {"Authorization": "Bearer t"}
+    body = {
+        "input": {"messages": [{"content": "hi"}]},
+        "target_url": "temporal://ProcessChat",
+    }
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/a2a/tasks/send", json=body, headers=headers)
+        tid = resp.json()["task_id"]
+        await asyncio.sleep(0.1)
+        status_resp = await client.get(f"/a2a/tasks/status/{tid}", headers=headers)
+
+    assert status_resp.json()["result"] == "Processed 2 tokens"


### PR DESCRIPTION
## Summary
- add Temporal worker and client examples
- support `temporal://` scheme in A2A queue
- document Temporal workflow usage
- test queue integration via monkeypatch when Temporal not installed
- refine worker to return result directly and use configurable queue

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683f0b814724832b90e0bce32bd8c383