### PR TITLE
Upgrade weaviate memory backend to v4 client

### DIFF
--- a/mem/__init__.py
+++ b/mem/__init__.py
@@ -11,7 +11,7 @@ class NullMemory:
 def _load_backend():
     backend = os.getenv("MEM_BACKEND", "none").lower()
     if backend == "weaviate":
-        from .weaviate import WeaviateMemory
+        from .weaviate import WeaviateMemory  # v4 client
 
         return WeaviateMemory()
 

--- a/mem/weaviate.py
+++ b/mem/weaviate.py
@@ -4,10 +4,11 @@
 from __future__ import annotations
 
 import os
-import uuid
 import time
+import uuid
 
-import weaviate
+from weaviate import WeaviateClient
+from weaviate.collections import Collection
 
 
 class WeaviateMemory:
@@ -17,14 +18,15 @@ class WeaviateMemory:
         # Lazily initialise the client using the configured URL.  This mirrors
         # the previous behaviour of a module level client but keeps it scoped to
         # the class instance.
-        self._client = weaviate.Client(os.getenv("WEAVIATE_URL"))
+        self._client = WeaviateClient(url=os.getenv("WEAVIATE_URL"))
+        self._collection: Collection = self._client.collections.get("MemoryEvent")
 
     async def write(self, event: dict) -> None:
         """Add an event object to the ``MemoryEvent`` class."""
 
         event["id"] = uuid.uuid4().hex
         event["timestamp"] = int(time.time())
-        self._client.data_object.create(event, "MemoryEvent", uuid=event["id"])
+        self._collection.data.insert(event)
 
 
 # Retain module level helper for backwards compatibility

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pytest>=8.0.0
 pytest-asyncio>=0.23.0
 
 # Memory Backend (Optional)
-weaviate-client>=4.4.0
+weaviate-client[embedded]>=4.15.0
 
 # Development Tools
 black>=24.1.0

--- a/script/migrate_v3_to_v4.py
+++ b/script/migrate_v3_to_v4.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""Migrate MemoryEvent objects from a v3 Weaviate instance to v4."""
+
+import os
+
+import requests
+from weaviate import WeaviateClient
+
+
+def main() -> None:
+    src_url = os.getenv("OLD_WEAVIATE_URL", "http://127.0.0.1:6666")
+    dest_url = os.getenv("WEAVIATE_URL", "http://127.0.0.1:6666")
+
+    # Fetch all MemoryEvent objects from the v3 instance
+    resp = requests.get(f"{src_url}/v1/objects?class=MemoryEvent")
+    resp.raise_for_status()
+    objects = resp.json().get("objects", [])
+
+    client = WeaviateClient(url=dest_url)
+    coll = client.collections.get("MemoryEvent")
+
+    for obj in objects:
+        props = obj.get("properties", {})
+        props["id"] = obj.get("id")
+        coll.data.insert(props)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- switch memory writer to use `WeaviateClient` v4 collection API
- bump weaviate-client requirement and add embedded extras
- provide helper to migrate data from v3 to v4
- tweak test helper order and mark weaviate backend as v4

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684032d93da0832b92d432cecdd4d858