### PR TITLE
Update Weaviate setup for Docker

### DIFF
--- a/.openai/project.yaml
+++ b/.openai/project.yaml
@@ -6,7 +6,7 @@ python_version: "3.12"
 setup_commands:
   - ["pip", "install", "-r", "requirements.txt"]
   - ["pip", "install", "weaviate-client[embedded]", "httpx", "pytest-asyncio"]
-  - ["python", "scripts/start_weaviate.py", "--port", "6666", "&"]
+  - ["python", "script/start_weaviate.py", "&"]
 
 env:
   WEAVIATE_URL: "http://127.0.0.1:6666"

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Run it next to any model server and get secure, shareable context in under 1 mi
 
 git clone https://github.com/attach-dev/attach-gateway.git && cd attach-gateway
 python -m venv .venv && source .venv/bin/activate
-pip install -r requirements.txt weaviate-client[embedded]
+pip install -r requirements.txt
 
-# 1) start embedded memory (background tab)
+# 1) start memory in Docker (background tab)
 python script/start_weaviate.py &
 
 # 2) export your short‑lived token
@@ -38,6 +38,7 @@ export OIDC_ISSUER=https://YOUR_DOMAIN.auth0.com
 export OIDC_AUD=ollama-local
 export MEM_BACKEND=weaviate
 export WEAVIATE_URL=http://127.0.0.1:6666
+export WEAVIATE_GRPC_PORT=50051
 
 # 3) run gateway
 uvicorn main:app --port 8080 &
@@ -119,10 +120,10 @@ flowchart TD
 
 ---
 
-## Live two‑agent demo (no Docker)
+## Live two‑agent demo
 
 ```bash
-# pane 1 – memory
+# pane 1 – memory (Docker)
 python script/start_weaviate.py
 
 # pane 2 – gateway

--- a/mem/weaviate.py
+++ b/mem/weaviate.py
@@ -9,6 +9,7 @@ import uuid
 
 from weaviate import WeaviateClient
 from weaviate.collections import Collection
+from weaviate.connect import ConnectionParams
 
 
 class WeaviateMemory:
@@ -18,7 +19,10 @@ class WeaviateMemory:
         # Lazily initialise the client using the configured URL.  This mirrors
         # the previous behaviour of a module level client but keeps it scoped to
         # the class instance.
-        self._client = WeaviateClient(url=os.getenv("WEAVIATE_URL"))
+        http_url = os.getenv("WEAVIATE_URL", "http://127.0.0.1:6666")
+        grpc_port = int(os.getenv("WEAVIATE_GRPC_PORT", 50051))
+        params = ConnectionParams.from_url(http_url, grpc_port=grpc_port)
+        self._client = WeaviateClient(connection_params=params)
         self._collection: Collection = self._client.collections.get("MemoryEvent")
 
     async def write(self, event: dict) -> None:

--- a/tests/test_sakana_logs.py
+++ b/tests/test_sakana_logs.py
@@ -61,7 +61,7 @@ async def test_integration_stores_in_weaviate(monkeypatch):
             self.data = types.SimpleNamespace(insert=self.insert)
 
     class DummyClient:
-        def __init__(self, url=None):
+        def __init__(self, *args, **kwargs):
             self.collections = types.SimpleNamespace(get=self.get)
 
         def get(self, name):


### PR DESCRIPTION
## Summary
- run Weaviate in Docker on port 6666
- default memory client to http://localhost:6666
- update README and project config

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844925ea508832bb4e130edc6a82e86