### PR TITLE
Switch to Weaviate v3 client

### DIFF
--- a/.openai/project.yaml
+++ b/.openai/project.yaml
@@ -5,7 +5,7 @@ python_version: "3.12"
 
 setup_commands:
   - ["pip", "install", "-r", "requirements.txt"]
-  - ["pip", "install", "weaviate-client[embedded]", "httpx", "pytest-asyncio"]
+  - ["pip", "install", "weaviate-client", "httpx", "pytest-asyncio"]
   - ["python", "script/start_weaviate.py", "&"]
 
 env:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ LLM engines such as **Ollama** or **vLLM** ship with **zero auth**.  Agent‑to�
 *   ✅ Verifies **OIDC / JWT** or **DID‑JWT**
 *   ✅ Stamps `X‑ATTACH‑User` + `X‑ATTACH‑Session` headers so every downstream agent/tool sees the same identity
 *   ✅ Implements `/a2a/tasks/send` + `/tasks/status` for Google A2A & OpenHands hand‑off
-*   ✅ Mirrors prompts & responses to a memory backend (Weaviate embedded by default)
+*   ✅ Mirrors prompts & responses to a memory backend (Weaviate Docker container by default)
 *   ✅ Workflow traces (Temporal)
 
 Run it next to any model server and get secure, shareable context in under 1 minute.
@@ -38,7 +38,6 @@ export OIDC_ISSUER=https://YOUR_DOMAIN.auth0.com
 export OIDC_AUD=ollama-local
 export MEM_BACKEND=weaviate
 export WEAVIATE_URL=http://127.0.0.1:6666
-export WEAVIATE_GRPC_PORT=50051
 
 # 3) run gateway
 uvicorn main:app --port 8080 &
@@ -82,7 +81,7 @@ flowchart TD
     end
 
     subgraph Memory
-        WV["Weaviate (embedded)\nclass MemoryEvent"]
+        WV["Weaviate (Docker)\nclass MemoryEvent"]
     end
 
     subgraph Engine

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,8 +7,8 @@ to start the gateway, both agents and the static web-page.
 
 ## Viewing memory
 
-You’re using the **embedded** (in-process) Weaviate server, so no
-cloud signup is required.
+This example uses the **Docker-based** Weaviate server started by
+`script/start_weaviate.py`, so no cloud signup is required.
 
 ```bash
 source .venv/bin/activate

--- a/examples/demo_view_memory.py
+++ b/examples/demo_view_memory.py
@@ -1,35 +1,33 @@
+"""
+Print the 10 latest MemoryEvent objects using Weaviate *v3* REST client.
+Run with a Docker-based server started like:
+  docker run -p 6666:8080 semitechnologies/weaviate:1.30.5
+"""
+
 import json
-from weaviate import WeaviateClient
-from weaviate.connect import ConnectionParams
 
-# Connect to Weaviate running in Docker
-client = WeaviateClient(
-    connection_params=ConnectionParams.from_url(
-        url="http://localhost:8080",  # Default Docker port
-        grpc_port=50051              # Default gRPC port
-    )
-)
+import weaviate
 
-# Explicitly connect to the client
-client.connect()
+# We expose 8080 inside the container – forwarded to 6666 on the host
+client = weaviate.Client("http://localhost:6666")
 
-# Check if the collection exists
-if "MemoryEvent" not in client.collections.list_all():
-    print("⚠️  No MemoryEvent collection yet (run a chat first)")
+# Make sure the class exists (user has chatted once)
+if not client.schema.contains({"class": "MemoryEvent"}):
+    print("⚠️  No MemoryEvent class yet.  Send a chat first.")
     exit(0)
 
-# Get the collection
-coll = client.collections.get("MemoryEvent")
-
-# Fetch the 10 most-recent objects
-objs = coll.query.fetch_objects(
-    limit=10,
-    sort=coll.sort.by_property("timestamp", asc=False)
+# Fetch the last 10 events, newest first
+result = (
+    client.query.get("MemoryEvent", ["id", "timestamp", "role", "content"])
+    .with_additional(["id"])
+    .with_limit(10)
+    .with_near_text({"concepts": ["*"]})  # noop, preserves creation order
+    .do()
 )
 
-print(f"last {len(objs)} memory events")
+objs = result["data"]["Get"]["MemoryEvent"]
+print(f"Fetched {len(objs)} events\n")
 for o in objs:
-    print(json.dumps(o.properties, indent=2)[:600], "...\n")
+    print(json.dumps(o, indent=2)[:600], "...\n")
 
-# Clean up
 client.close()

--- a/mem/__init__.py
+++ b/mem/__init__.py
@@ -11,7 +11,7 @@ class NullMemory:
 def _load_backend():
     backend = os.getenv("MEM_BACKEND", "none").lower()
     if backend == "weaviate":
-        from .weaviate import WeaviateMemory  # v4 client
+        from .weaviate import WeaviateMemory  # v3 REST client
 
         return WeaviateMemory()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pytest>=8.0.0
 pytest-asyncio>=0.23.0
 
 # Memory Backend (Optional)
-weaviate-client[embedded]>=4.15.0
+weaviate-client>=3.26.7,<4.0.0
 
 # Development Tools
 black>=24.1.0


### PR DESCRIPTION
## Summary
- update docs for Docker-based Weaviate memory
- show example query using a v3 near-text trick for ordering
- ensure memory writes use run_in_executor

## Testing
- `isort README.md examples/README.md examples/demo_view_memory.py mem/weaviate.py`
- `black mem/weaviate.py examples/demo_view_memory.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68453cc78d1c832bb548e73b9c690fa2