### PR TITLE
Fix Auth0 setup in demo2 page

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ export WEAVIATE_URL=http://127.0.0.1:6666
 # 3) run gateway
 uvicorn main:app --port 8080 &
 
+# The gateway exposes your Auth0 credentials for the demo UI at
+# `/auth/config`. The values are read from `AUTH0_DOMAIN`,
+# `AUTH0_CLIENT` and `OIDC_AUD`.
+
 # 4) make a protected Ollama call via the gateway
 curl -H "Authorization: Bearer $JWT" \
      -d '{"model":"tinyllama","prompt":"hello"}' \

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,3 +13,5 @@ This example uses the **Docker-based** Weaviate server started by
 ```bash
 source .venv/bin/activate
 python examples/demo_view_memory.py
+
+```

--- a/examples/static/demo2.html
+++ b/examples/static/demo2.html
@@ -154,12 +154,17 @@
 <script type="module">
 const signinBtn  = document.getElementById('signinBtn');
 const signoutBtn = document.getElementById('signoutBtn');
+const GW = location.protocol + '//' + location.hostname + ':8080';
 
+const cfg = await fetch(`${GW}/auth/config`).then(r => r.json());
 const auth0 = await createAuth0Client({
-  domain:   "YOUR_DOMAIN.auth0.com",
-  clientId: "YOUR_CLIENT_ID",
-  audience: "ollama-local",
-  cacheLocation: "localstorage",
+  domain: cfg.domain,
+  clientId: cfg.client_id,
+  authorizationParams: {
+    audience: cfg.audience,
+    redirect_uri: window.location.origin + '/demo2.html'
+  },
+  cacheLocation: 'localstorage',
   useRefreshTokens: true,
 });
 
@@ -188,7 +193,6 @@ const coderTab = document.getElementById('coderTab');
 const sendBtn = document.getElementById('sendBtn');
 const logPanel = document.getElementById('logPanel');
 const inputBar = document.getElementById('inputBar');
-const GW = location.protocol + '//' + location.hostname + ':8080';
 const PLANNER_URL = location.protocol + '//' + location.hostname + ':8100/api/chat';
 const CODER_URL = location.protocol + '//' + location.hostname + ':8101/api/chat';
 let activeRole = 'planner';


### PR DESCRIPTION
## Summary
- fetch Auth0 configuration from the gateway
- initialise Auth0 client with dynamic values
- keep login required before using the demo
- document `/auth/config` endpoint for demo setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68497c2cbd28832b9287539b760ec87d