### PR TITLE
Add debug prints in auth flow

### DIFF
--- a/auth/oidc.py
+++ b/auth/oidc.py
@@ -97,6 +97,8 @@ def verify_jwt(token: str, *, leeway: int = 60) -> dict[str, Any]:
     if not kid:
         raise ValueError("JWT header missing 'kid'")
 
+    print("ISSUER =", issuer, "AUD =", audience, "KID =", kid)
+
     # 2) Locate JWK (with one forced refresh on miss)
     keys = _jwks(issuer)
     key_cfg = next((k for k in keys if k["kid"] == kid), None)

--- a/middleware/auth.py
+++ b/middleware/auth.py
@@ -7,7 +7,7 @@ This file *must* live inside the project's `middleware/` package so that
 
 from __future__ import annotations
 
-from fastapi import Request, HTTPException
+from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 
 from auth.oidc import verify_jwt  # your existing verifier (RS256 / ES256 only)
@@ -22,18 +22,21 @@ EXCLUDED_PATHS = {
     "/openapi.json",
 }
 
+
 async def jwt_auth_mw(request: Request, call_next):
     """
-    • Extracts the Bearer token from the `Authorization` header.  
-    • Verifies it with `auth.oidc.verify_jwt`.  
-    • Stores the `sub` claim in `request.state.sub` for downstream middleware.  
+    • Extracts the Bearer token from the `Authorization` header.
+    • Verifies it with `auth.oidc.verify_jwt`.
+    • Stores the `sub` claim in `request.state.sub` for downstream middleware.
     • Rejects the request with 401 on any failure.
     • Skips authentication for excluded paths.
     """
+    print("AUTH HDR =", request.headers.get("Authorization", "")[:80])
+
     # Skip authentication for excluded paths
     if request.url.path in EXCLUDED_PATHS:
         return await call_next(request)
-    
+
     auth_header = request.headers.get("authorization", "")
     if not auth_header.startswith("Bearer "):
         return JSONResponse(status_code=401, content={"detail": "Missing Bearer token"})
@@ -42,9 +45,9 @@ async def jwt_auth_mw(request: Request, call_next):
 
     try:
         claims = verify_jwt(token, leeway=_CLOCK_SKEW)
-    except Exception as exc: 
+    except Exception as exc:
         return JSONResponse(status_code=401, content={"detail": str(exc)})
-    
+
     # attach the user id (sub) for the session-middleware
     request.state.sub = claims["sub"]
 


### PR DESCRIPTION
## Summary
- log issuer, audience, and kid during JWT verification
- log the Authorization header on each request

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d3331108c832b986aaaf85ee1a65c