### PR TITLE
Add metrics helper and usage extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ export USAGE_BACKEND=prometheus  # or openmeter/null
 A Prometheus counter `attach_usage_tokens_total{user,direction,model}` is
 exposed for Grafana dashboards.
 
+### Scraping metrics
+
+```bash
+curl http://localhost:8080/metrics
+```
+
 ## Token quotas
 
 Attach Gateway can enforce per-user token limits. Install the optional

--- a/attach/gateway.py
+++ b/attach/gateway.py
@@ -22,6 +22,7 @@ from middleware.quota import TokenQuotaMiddleware
 from middleware.session import session_mw
 from proxy.engine import router as proxy_router
 from usage.factory import get_usage_backend
+from usage.metrics import mount_metrics
 
 # Import version from parent package
 from . import __version__
@@ -129,6 +130,7 @@ def create_app(config: Optional[AttachConfig] = None) -> FastAPI:
         description="Identity & Memory side-car for LLM engines",
         version=__version__,
     )
+    mount_metrics(app)
 
     # Add middleware
     app.middleware("http")(jwt_auth_mw)

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from middleware.auth import jwt_auth_mw  # ← your auth middleware
 from middleware.session import session_mw  # ← generates session-id header
 from proxy.engine import router as proxy_router
 from usage.factory import get_usage_backend
+from usage.metrics import mount_metrics
 
 # At the top, make the import conditional
 try:
@@ -132,6 +133,7 @@ if QUOTA_AVAILABLE and os.getenv("MAX_TOKENS_PER_MIN"):
 # Create app without middleware first
 app = FastAPI(title="attach-gateway", middleware=middlewares)
 app.state.usage = get_usage_backend(os.getenv("USAGE_BACKEND", "null"))
+mount_metrics(app)
 
 
 @app.get("/auth/config")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ dependencies = [
 memory = ["weaviate-client>=3.26.7,<4.0.0"]
 temporal = ["temporalio>=1.5.0"]
 quota = ["tiktoken>=0.5.0"]
+usage = [
+    "prometheus_client>=0.20.0",
+    "openmeter>=0.4.0",
+]
 dev = [
     "pytest>=8.0.0", 
     "pytest-asyncio>=0.23.0",

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -1,0 +1,35 @@
+import os
+
+import pytest
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+
+from middleware.quota import TokenQuotaMiddleware
+from usage.factory import get_usage_backend
+from usage.metrics import mount_metrics
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint(monkeypatch):
+    os.environ["USAGE_BACKEND"] = "prometheus"
+    os.environ["MAX_TOKENS_PER_MIN"] = "1000"
+
+    app = FastAPI()
+    mount_metrics(app)
+
+    app.add_middleware(TokenQuotaMiddleware)
+    app.state.usage = get_usage_backend(os.getenv("USAGE_BACKEND", "null"))
+
+    @app.post("/echo")
+    async def echo(request: Request):
+        data = await request.json()
+        return {"msg": data.get("msg")}
+
+    transport = ASGITransport(app=app)
+    headers = {"X-Attach-User": "bob"}
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post("/echo", json={"msg": "hi"}, headers=headers)
+        resp = await client.get("/metrics")
+
+    assert "attach_usage_tokens_total" in resp.text
+    assert "bob" in resp.text

--- a/usage/metrics.py
+++ b/usage/metrics.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Utilities for exposing Attach Gateway usage metrics."""
+
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse, Response
+
+
+def mount_metrics(app: FastAPI) -> None:
+    """Attach a Prometheus-compatible ``/metrics`` route to ``app``."""
+
+    @app.get("/metrics", include_in_schema=False)
+    async def metrics() -> Response:  # noqa: D401
+        usage = getattr(app.state, "usage", None)
+        if usage is None:
+            return PlainTextResponse("# No usage backend configured\n")
+        try:
+            from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, generate_latest
+        except ImportError:
+            counter = getattr(usage, "counter", None)
+            if counter is None or not hasattr(counter, "values"):
+                return PlainTextResponse("# No metrics available\n")
+            lines = [
+                "# HELP attach_usage_tokens_total Total tokens processed by Attach Gateway",
+                "# TYPE attach_usage_tokens_total counter",
+            ]
+            for (u, d, m), v in counter.values.items():
+                lines.append(
+                    f'attach_usage_tokens_total{{user="{u}",direction="{d}",model="{m}"}} {v}'
+                )
+            return PlainTextResponse("\n".join(lines) + "\n")
+        else:
+            if not hasattr(usage, "counter"):
+                return PlainTextResponse("# No usage counter\n")
+            return PlainTextResponse(
+                generate_latest(REGISTRY), media_type=CONTENT_TYPE_LATEST
+            )


### PR DESCRIPTION
## Summary
- factor `/metrics` into reusable helper `mount_metrics`
- apply helper to both entrypoints
- update metrics endpoint test
- include `prometheus_client` in usage extras
- check for missing counter before dumping prometheus registry

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68770db40534832ba0a4e5d16edbe5d0