### PR TITLE
Quota middleware v2 – streaming-safe token accounting + OpenMeter direct HTTP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,8 @@ WEAVIATE_URL=http://localhost:8081
 MAX_TOKENS_PER_MIN=60000
 QUOTA_ENCODING=cl100k_base
 
+USAGE_METERING=null
+
 # Development: Auth0 credentials for dev_login script
 # AUTH0_DOMAIN=your-domain.auth0.com
 # AUTH0_CLIENT=your-client-id

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,18 @@ This repo is used for the Attach Gateway service. Follow these guidelines for co
 
 ## Development Tools
 - Code should be formatted with `black` and imports sorted with `isort`.
+
+## 🔒  Memory & /mem/events are **read-only**
+
+> **Do not touch any memory-related code.**
+
+* **Off-limits files / symbols**  
+  * `mem/**`
+  * `main.py` → the `/mem/events` route and **all** `MemoryEvent` logic  
+  * Any Weaviate queries, inserts, or schema
+
+* PRs that change, remove, or “refactor” these areas **will be rejected**.  
+  Only work on the explicitly assigned task (e.g. billing hooks).
+
+* If your change needs to interact with memory, open an issue first and wait
+  for maintainer approval.

--- a/README.md
+++ b/README.md
@@ -261,16 +261,21 @@ export USAGE_METERING=prometheus
 #### OpenMeter (Stripe / ClickHouse)
 
 ```bash
-pip install "attach-gateway[usage]"
-export MAX_TOKENS_PER_MIN=60000
-export USAGE_METERING=openmeter
-export OPENMETER_API_KEY=...
-export OPENMETER_URL=http://localhost:8888   # optional self-host, defaults to https://openmeter.cloud
+# No additional dependencies needed - uses direct HTTP API
+export MAX_TOKENS_PER_MIN=60000              # Required: enables quota middleware
+export USAGE_METERING=openmeter              # Required: activates OpenMeter backend  
+export OPENMETER_API_KEY=your-api-key-here   # Required: API authentication
+export OPENMETER_URL=https://openmeter.cloud # Optional: defaults to https://openmeter.cloud
 ```
 
-Events land in the tokens meter of OpenMeter and can sync to Stripe.
+Events are sent directly to OpenMeter's HTTP API and are processed by the LLM tokens meter for billing integration with Stripe.
 
-The gateway runs fine without these vars; metering activates only when both USAGE_METERING=openmeter and OPENMETER_API_KEY are set.
+> **⚠️ All three variables are required for OpenMeter to work:**  
+> - `MAX_TOKENS_PER_MIN` enables the quota middleware that records usage events  
+> - `USAGE_METERING=openmeter` activates the OpenMeter backend  
+> - `OPENMETER_API_KEY` provides authentication to OpenMeter's API  
+
+The gateway gracefully falls back to `NullUsageBackend` if any required variable is missing.
 
 ### Scraping metrics
 
@@ -281,7 +286,7 @@ curl -H "Authorization: Bearer $JWT" http://localhost:8080/metrics
 ## Token quotas
 
 Attach Gateway can enforce per-user token limits. Install the optional
-dependency with `pip install attach-gateway[quota]` and set
+dependency with `pip install attach-dev[quota]` and set
 `MAX_TOKENS_PER_MIN` in your environment to enable the middleware. The
 counter defaults to the `cl100k_base` encoding; override with
 `QUOTA_ENCODING` if your model uses a different tokenizer. The default
@@ -297,7 +302,7 @@ production.
 ```bash
 # Optional: Enable token quotas
 export MAX_TOKENS_PER_MIN=60000
-pip install tiktoken  # or pip install attach-gateway[quota]
+pip install tiktoken  # or pip install attach-dev[quota]
 ```
 
 To customize the tokenizer:

--- a/README.md
+++ b/README.md
@@ -234,6 +234,18 @@ curl -X POST /v1/logs \
 # => HTTP/1.1 202 Accepted
 ```
 
+## Usage hooks
+
+Emit token usage metrics for every request. Choose a backend via
+`USAGE_BACKEND`:
+
+```bash
+export USAGE_BACKEND=prometheus  # or openmeter/null
+```
+
+A Prometheus counter `attach_usage_tokens_total{user,direction,model}` is
+exposed for Grafana dashboards.
+
 ## Token quotas
 
 Attach Gateway can enforce per-user token limits. Install the optional
@@ -244,6 +256,9 @@ counter defaults to the `cl100k_base` encoding; override with
 in-memory store works in a single process and is not shared between
 workers—requests retried across processes may be double-counted. Use Redis
 for production deployments.
+If `tiktoken` is missing, a byte-count fallback is used which counts about
+four times more tokens than the `cl100k` tokenizer – install `tiktoken` in
+production.
 
 ### Enable token quotas
 

--- a/README.md
+++ b/README.md
@@ -237,14 +237,15 @@ curl -X POST /v1/logs \
 ## Usage hooks
 
 Emit token usage metrics for every request. Choose a backend via
-`USAGE_BACKEND`:
+`USAGE_METERING` (alias `USAGE_BACKEND`):
 
 ```bash
-export USAGE_BACKEND=prometheus  # or openmeter/null
+export USAGE_METERING=prometheus  # or null
 ```
 
 A Prometheus counter `attach_usage_tokens_total{user,direction,model}` is
 exposed for Grafana dashboards.
+Set `USAGE_METERING=null` (the default) to disable metering entirely.
 
 > **⚠️ Usage hooks depend on the quota middleware.**  
 > Make sure `MAX_TOKENS_PER_MIN` is set (any positive number) so the  
@@ -254,8 +255,22 @@ exposed for Grafana dashboards.
 ```bash
 # Enable usage tracking (set any reasonable limit)
 export MAX_TOKENS_PER_MIN=60000
-export USAGE_BACKEND=prometheus
+export USAGE_METERING=prometheus
 ```
+
+#### OpenMeter (Stripe / ClickHouse)
+
+```bash
+pip install "attach-gateway[usage]"
+export MAX_TOKENS_PER_MIN=60000
+export USAGE_METERING=openmeter
+export OPENMETER_API_KEY=...
+export OPENMETER_URL=http://localhost:8888   # optional self-host, defaults to https://openmeter.cloud
+```
+
+Events land in the tokens meter of OpenMeter and can sync to Stripe.
+
+The gateway runs fine without these vars; metering activates only when both USAGE_METERING=openmeter and OPENMETER_API_KEY are set.
 
 ### Scraping metrics
 

--- a/README.md
+++ b/README.md
@@ -246,10 +246,21 @@ export USAGE_BACKEND=prometheus  # or openmeter/null
 A Prometheus counter `attach_usage_tokens_total{user,direction,model}` is
 exposed for Grafana dashboards.
 
+> **⚠️ Usage hooks depend on the quota middleware.**  
+> Make sure `MAX_TOKENS_PER_MIN` is set (any positive number) so the  
+> `TokenQuotaMiddleware` is enabled; the middleware is what records usage  
+> events that feed Prometheus.
+
+```bash
+# Enable usage tracking (set any reasonable limit)
+export MAX_TOKENS_PER_MIN=60000
+export USAGE_BACKEND=prometheus
+```
+
 ### Scraping metrics
 
 ```bash
-curl http://localhost:8080/metrics
+curl -H "Authorization: Bearer $JWT" http://localhost:8080/metrics
 ```
 
 ## Token quotas

--- a/README.md
+++ b/README.md
@@ -246,6 +246,12 @@ export USAGE_BACKEND=prometheus  # or openmeter/null
 A Prometheus counter `attach_usage_tokens_total{user,direction,model}` is
 exposed for Grafana dashboards.
 
+### Scraping metrics
+
+```bash
+curl http://localhost:8080/metrics
+```
+
 ## Token quotas
 
 Attach Gateway can enforce per-user token limits. Install the optional

--- a/attach/gateway.py
+++ b/attach/gateway.py
@@ -21,7 +21,7 @@ from middleware.auth import jwt_auth_mw
 from middleware.quota import TokenQuotaMiddleware
 from middleware.session import session_mw
 from proxy.engine import router as proxy_router
-from usage.factory import get_usage_backend
+from usage.factory import _select_backend, get_usage_backend
 from usage.metrics import mount_metrics
 
 # Import version from parent package
@@ -147,6 +147,7 @@ def create_app(config: Optional[AttachConfig] = None) -> FastAPI:
     memory_backend = get_memory_backend(config.mem_backend, config)
     app.state.memory = memory_backend
     app.state.config = config
-    app.state.usage = get_usage_backend(os.getenv("USAGE_BACKEND", "null"))
+    backend_selector = _select_backend()
+    app.state.usage = get_usage_backend(backend_selector)
 
     return app

--- a/attach/gateway.py
+++ b/attach/gateway.py
@@ -22,6 +22,7 @@ from middleware.quota import TokenQuotaMiddleware
 from middleware.session import session_mw
 from proxy.engine import router as proxy_router
 from usage.factory import get_usage_backend
+from usage.metrics import mount_metrics
 
 # Import version from parent package
 from . import __version__
@@ -129,6 +130,7 @@ def create_app(config: Optional[AttachConfig] = None) -> FastAPI:
         description="Identity & Memory side-car for LLM engines",
         version=__version__,
     )
+    mount_metrics(app)
 
     # Add middleware
     app.middleware("http")(jwt_auth_mw)

--- a/attach/gateway.py
+++ b/attach/gateway.py
@@ -23,6 +23,7 @@ from middleware.session import session_mw
 from proxy.engine import router as proxy_router
 from usage.factory import _select_backend, get_usage_backend
 from usage.metrics import mount_metrics
+from utils.env import int_env
 
 # Import version from parent package
 from . import __version__
@@ -135,7 +136,9 @@ def create_app(config: Optional[AttachConfig] = None) -> FastAPI:
     # Add middleware
     app.middleware("http")(jwt_auth_mw)
     app.middleware("http")(session_mw)
-    app.add_middleware(TokenQuotaMiddleware)
+    limit = int_env("MAX_TOKENS_PER_MIN", 60000)
+    if limit is not None:
+        app.add_middleware(TokenQuotaMiddleware)
 
     # Add routes
     app.include_router(a2a_router)

--- a/attach/gateway.py
+++ b/attach/gateway.py
@@ -21,6 +21,7 @@ from middleware.auth import jwt_auth_mw
 from middleware.quota import TokenQuotaMiddleware
 from middleware.session import session_mw
 from proxy.engine import router as proxy_router
+from usage.factory import get_usage_backend
 
 # Import version from parent package
 from . import __version__
@@ -144,5 +145,6 @@ def create_app(config: Optional[AttachConfig] = None) -> FastAPI:
     memory_backend = get_memory_backend(config.mem_backend, config)
     app.state.memory = memory_backend
     app.state.config = config
+    app.state.usage = get_usage_backend(os.getenv("USAGE_BACKEND", "null"))
 
     return app

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from middleware.session import session_mw  # ← generates session-id header
 from proxy.engine import router as proxy_router
 from usage.factory import _select_backend, get_usage_backend
 from usage.metrics import mount_metrics
+from utils.env import int_env
 
 # At the top, make the import conditional
 try:
@@ -126,8 +127,9 @@ middlewares = [
     Middleware(BaseHTTPMiddleware, dispatch=session_mw),
 ]
 
-# Only add quota middleware if tiktoken is available AND user configured it
-if QUOTA_AVAILABLE and os.getenv("MAX_TOKENS_PER_MIN"):
+# Only add quota middleware if tiktoken is available and a positive limit is set
+limit = int_env("MAX_TOKENS_PER_MIN", 60000)
+if QUOTA_AVAILABLE and limit is not None:
     middlewares.append(Middleware(TokenQuotaMiddleware))
 
 # Create app without middleware first

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from mem import write as mem_write  # Import memory write function
 from middleware.auth import jwt_auth_mw  # ← your auth middleware
 from middleware.session import session_mw  # ← generates session-id header
 from proxy.engine import router as proxy_router
-from usage.factory import get_usage_backend
+from usage.factory import _select_backend, get_usage_backend
 from usage.metrics import mount_metrics
 
 # At the top, make the import conditional
@@ -132,7 +132,8 @@ if QUOTA_AVAILABLE and os.getenv("MAX_TOKENS_PER_MIN"):
 
 # Create app without middleware first
 app = FastAPI(title="attach-gateway", middleware=middlewares)
-app.state.usage = get_usage_backend(os.getenv("USAGE_BACKEND", "null"))
+backend_selector = _select_backend()
+app.state.usage = get_usage_backend(backend_selector)
 mount_metrics(app)
 
 

--- a/main.py
+++ b/main.py
@@ -14,6 +14,7 @@ from middleware.auth import jwt_auth_mw  # ← your auth middleware
 from middleware.session import session_mw  # ← generates session-id header
 from proxy.engine import router as proxy_router
 from usage.factory import get_usage_backend
+from usage.metrics import mount_metrics
 
 # At the top, make the import conditional
 try:
@@ -132,6 +133,7 @@ if QUOTA_AVAILABLE and os.getenv("MAX_TOKENS_PER_MIN"):
 # Create app without middleware first
 app = FastAPI(title="attach-gateway", middleware=middlewares)
 app.state.usage = get_usage_backend(os.getenv("USAGE_BACKEND", "null"))
+mount_metrics(app)
 
 
 @app.get("/auth/config")

--- a/middleware/quota.py
+++ b/middleware/quota.py
@@ -406,6 +406,9 @@ class TokenQuotaMiddleware(BaseHTTPMiddleware):
 
             total = await self.store.peek_total(user)
             if total > self.max_tokens:
+                retry_after = self.window              # simple worst-case
+                response.status_code = 429
+                response.headers["Retry-After"] = str(retry_after)
                 usage["detail"] = "token quota exceeded post-stream"
 
             response.headers.update(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ memory = ["weaviate-client>=3.26.7,<4.0.0"]
 temporal = ["temporalio>=1.5.0"]
 quota = ["tiktoken>=0.5.0"]
 usage = [
-    "prometheus_client>=0.20.0"
+    "prometheus_client>=0.20.0",
+    "openmeter>=1.0.0b188,<2",  # openmeter>=1.0.0b188 requires Python >= 3.9
 ]
 dev = [
     "pytest>=8.0.0", 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,10 @@ dependencies = [
 memory = ["weaviate-client>=3.26.7,<4.0.0"]
 temporal = ["temporalio>=1.5.0"]
 quota = ["tiktoken>=0.5.0"]
+usage = [
+    "prometheus_client>=0.20.0",
+    "openmeter>=0.4.0",
+]
 dev = [
     "pytest>=8.0.0", 
     "pytest-asyncio>=0.23.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ temporal = ["temporalio>=1.5.0"]
 quota = ["tiktoken>=0.5.0"]
 usage = [
     "prometheus_client>=0.20.0",
-    "openmeter>=1.0.0b188,<2",  # openmeter>=1.0.0b188 requires Python >= 3.9
 ]
 dev = [
     "pytest>=8.0.0", 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,7 @@ memory = ["weaviate-client>=3.26.7,<4.0.0"]
 temporal = ["temporalio>=1.5.0"]
 quota = ["tiktoken>=0.5.0"]
 usage = [
-    "prometheus_client>=0.20.0",
-    "openmeter>=0.4.0",
+    "prometheus_client>=0.20.0"
 ]
 dev = [
     "pytest>=8.0.0", 

--- a/tests/test_metrics_endpoint.py
+++ b/tests/test_metrics_endpoint.py
@@ -1,0 +1,35 @@
+import os
+
+import pytest
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+
+from middleware.quota import TokenQuotaMiddleware
+from usage.factory import get_usage_backend
+from usage.metrics import mount_metrics
+
+
+@pytest.mark.asyncio
+async def test_metrics_endpoint(monkeypatch):
+    os.environ["USAGE_BACKEND"] = "prometheus"
+    os.environ["MAX_TOKENS_PER_MIN"] = "1000"
+
+    app = FastAPI()
+    mount_metrics(app)
+
+    app.add_middleware(TokenQuotaMiddleware)
+    app.state.usage = get_usage_backend(os.getenv("USAGE_BACKEND", "null"))
+
+    @app.post("/echo")
+    async def echo(request: Request):
+        data = await request.json()
+        return {"msg": data.get("msg")}
+
+    transport = ASGITransport(app=app)
+    headers = {"X-Attach-User": "bob"}
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post("/echo", json={"msg": "hi"}, headers=headers)
+        resp = await client.get("/metrics")
+
+    assert "attach_usage_tokens_total" in resp.text
+    assert "bob" in resp.text

--- a/tests/test_prometheus_fallback.py
+++ b/tests/test_prometheus_fallback.py
@@ -1,0 +1,18 @@
+import os
+import pytest
+from usage.factory import get_usage_backend  
+
+pytest.importorskip("prometheus_client")
+
+def test_prometheus_backend_falls_back_to_null_when_unavailable():
+    os.environ["USAGE_BACKEND"] = "prometheus"
+    
+    # This should return NullUsageBackend when prometheus_client unavailable
+    backend = get_usage_backend("prometheus")
+    
+    if hasattr(backend, 'counter'):
+        # prometheus_client available - got PrometheusUsageBackend
+        assert backend.__class__.__name__ == 'PrometheusUsageBackend'
+    else:
+        # prometheus_client unavailable - got NullUsageBackend fallback
+        assert backend.__class__.__name__ == 'NullUsageBackend' 

--- a/tests/test_prometheus_fallback.py
+++ b/tests/test_prometheus_fallback.py
@@ -1,18 +1,19 @@
-import os
 import pytest
-from usage.factory import get_usage_backend  
+
+from usage.factory import get_usage_backend
 
 pytest.importorskip("prometheus_client")
 
-def test_prometheus_backend_falls_back_to_null_when_unavailable():
-    os.environ["USAGE_BACKEND"] = "prometheus"
-    
+
+def test_prometheus_backend_falls_back_to_null_when_unavailable(monkeypatch):
+    monkeypatch.setenv("USAGE_METERING", "prometheus")
+
     # This should return NullUsageBackend when prometheus_client unavailable
     backend = get_usage_backend("prometheus")
-    
-    if hasattr(backend, 'counter'):
+
+    if hasattr(backend, "counter"):
         # prometheus_client available - got PrometheusUsageBackend
-        assert backend.__class__.__name__ == 'PrometheusUsageBackend'
+        assert backend.__class__.__name__ == "PrometheusUsageBackend"
     else:
         # prometheus_client unavailable - got NullUsageBackend fallback
-        assert backend.__class__.__name__ == 'NullUsageBackend' 
+        assert backend.__class__.__name__ == "NullUsageBackend"

--- a/tests/test_token_quota_middleware.py
+++ b/tests/test_token_quota_middleware.py
@@ -67,9 +67,8 @@ async def test_midstream_over_limit_rolls_back(monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/stream", headers=headers)
-        text = resp.text
 
-    assert resp.status_code == 200
-    assert text == "hi"
+    assert resp.status_code == 429
+    assert resp.json()["detail"] == "token quota exceeded"
     total = await store.peek_total("carol")
     assert total == 2

--- a/tests/test_usage_openmeter.py
+++ b/tests/test_usage_openmeter.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import types
+
+import pytest
+
+
+class DummyEvents:
+    def __init__(self):
+        self.called = None
+
+    async def create(self, **event):
+        self.called = event
+
+
+class DummyClient:
+    def __init__(self, api_key: str, base_url: str = "https://openmeter.cloud") -> None:
+        self.api_key = api_key
+        self.base_url = base_url
+        self.events = DummyEvents()
+
+    async def aclose(self) -> None:
+        pass
+
+
+dummy_module = types.SimpleNamespace(Client=DummyClient)
+
+
+@pytest.mark.asyncio
+async def test_openmeter_backend_create(monkeypatch):
+    monkeypatch.setitem(sys.modules, "openmeter", dummy_module)
+    if "usage.backends" in sys.modules:
+        del sys.modules["usage.backends"]
+    if "usage.factory" in sys.modules:
+        del sys.modules["usage.factory"]
+    from usage.factory import get_usage_backend
+
+    monkeypatch.setenv("OPENMETER_API_KEY", "k")
+    monkeypatch.setenv("OPENMETER_URL", "https://example.com")
+
+    backend = get_usage_backend("openmeter")
+    assert backend.__class__.__name__ == "OpenMeterBackend"
+    await backend.record(user="bob", tokens_in=1, tokens_out=2, model="m")
+    await backend.aclose()
+
+    called = backend.client.events.called
+    assert called["type"] == "tokens"
+    assert called["subject"] == "bob"
+    assert called["project"] is None
+    assert called["data"] == {"tokens_in": 1, "tokens_out": 2, "model": "m"}
+    assert "time" in called
+
+
+def test_openmeter_backend_missing_key(monkeypatch):
+    monkeypatch.setitem(sys.modules, "openmeter", dummy_module)
+    if "usage.backends" in sys.modules:
+        del sys.modules["usage.backends"]
+    if "usage.factory" in sys.modules:
+        del sys.modules["usage.factory"]
+    from usage.factory import get_usage_backend
+
+    monkeypatch.setenv("USAGE_METERING", "openmeter")
+    monkeypatch.delenv("OPENMETER_API_KEY", raising=False)
+
+    backend = get_usage_backend("openmeter")
+    assert backend.__class__.__name__ == "NullUsageBackend"

--- a/tests/test_usage_prometheus.py
+++ b/tests/test_usage_prometheus.py
@@ -32,4 +32,5 @@ async def test_prometheus_backend_counts_tokens(monkeypatch):
     out_val = c.labels(user="bob", direction="out", model="unknown")._value.get()
     assert in_val > 0
     assert out_val > 0
-    assert in_val + out_val == sum(c.values.values())
+    # Removed: assert in_val + out_val == sum(c.values.values())
+    # The 'values' attribute only exists in the fallback Counter, not the real Prometheus Counter

--- a/tests/test_usage_prometheus.py
+++ b/tests/test_usage_prometheus.py
@@ -1,0 +1,35 @@
+import os
+
+import pytest
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+
+from middleware.quota import TokenQuotaMiddleware
+from usage.factory import get_usage_backend
+
+
+@pytest.mark.asyncio
+async def test_prometheus_backend_counts_tokens(monkeypatch):
+    os.environ["USAGE_BACKEND"] = "prometheus"
+    os.environ["MAX_TOKENS_PER_MIN"] = "1000"
+    app = FastAPI()
+    app.add_middleware(TokenQuotaMiddleware)
+    app.state.usage = get_usage_backend(os.getenv("USAGE_BACKEND", "null"))
+
+    @app.post("/echo")
+    async def echo(request: Request):
+        data = await request.json()
+        return {"msg": data.get("msg")}
+
+    transport = ASGITransport(app=app)
+    headers = {"X-Attach-User": "bob"}
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        await client.post("/echo", json={"msg": "hi"}, headers=headers)
+        await client.post("/echo", json={"msg": "there"}, headers=headers)
+
+    c = app.state.usage.counter
+    in_val = c.labels(user="bob", direction="in", model="unknown")._value.get()
+    out_val = c.labels(user="bob", direction="out", model="unknown")._value.get()
+    assert in_val > 0
+    assert out_val > 0
+    assert in_val + out_val == sum(c.values.values())

--- a/tests/test_usage_prometheus.py
+++ b/tests/test_usage_prometheus.py
@@ -1,14 +1,15 @@
 import os
 import sys
+
 import pytest
 from fastapi import FastAPI, Request
 from httpx import ASGITransport, AsyncClient
 
 # Force reload to pick up prometheus_client if just installed
-if 'usage.backends' in sys.modules:
-    del sys.modules['usage.backends']
-if 'usage.factory' in sys.modules:
-    del sys.modules['usage.factory']
+if "usage.backends" in sys.modules:
+    del sys.modules["usage.backends"]
+if "usage.factory" in sys.modules:
+    del sys.modules["usage.factory"]
 
 from middleware.quota import TokenQuotaMiddleware
 from usage.factory import get_usage_backend
@@ -21,11 +22,11 @@ pytest.importorskip("prometheus_client")  # ← Skip entire test if not installe
 async def test_prometheus_backend_counts_tokens(monkeypatch):
     # Verify we actually get PrometheusUsageBackend
     backend = get_usage_backend("prometheus")
-    if not hasattr(backend, 'counter'):
+    if not hasattr(backend, "counter"):
         pytest.skip("prometheus_client not available, got NullUsageBackend")
-    
-    os.environ["USAGE_BACKEND"] = "prometheus"
-    os.environ["MAX_TOKENS_PER_MIN"] = "1000"
+
+    monkeypatch.setenv("USAGE_METERING", "prometheus")
+    monkeypatch.setenv("MAX_TOKENS_PER_MIN", "1000")
     app = FastAPI()
     app.add_middleware(TokenQuotaMiddleware)
     app.state.usage = backend  # Use the backend we verified

--- a/usage/__init__.py
+++ b/usage/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+"""Public API for Attach Gateway usage accounting."""
+
+from .backends import AbstractUsageBackend
+from .factory import get_usage_backend
+
+__all__ = ["AbstractUsageBackend", "get_usage_backend"]

--- a/usage/backends.py
+++ b/usage/backends.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+"""Usage accounting backends for Attach Gateway."""
+
+from typing import Protocol
+
+try:
+    from prometheus_client import Counter
+except Exception:  # pragma: no cover - optional dep
+    Counter = None  # type: ignore
+
+    class Counter:  # type: ignore[misc]
+        """Minimal in-memory Counter fallback."""
+
+        def __init__(self, name: str, desc: str, labelnames: list[str]):
+            self.labelnames = labelnames
+            self.values: dict[tuple[str, ...], float] = {}
+
+        def labels(self, **labels):
+            key = tuple(labels.get(name, "") for name in self.labelnames)
+            self.values.setdefault(key, 0.0)
+
+            class _Wrapper:
+                def __init__(self, parent: Counter, k: tuple[str, ...]) -> None:
+                    self.parent = parent
+                    self.k = k
+
+                def inc(self, amt: float) -> None:
+                    self.parent.values[self.k] += amt
+
+                @property
+                def _value(self):
+                    class V:
+                        def __init__(self, parent: Counter, k: tuple[str, ...]):
+                            self.parent = parent
+                            self.k = k
+
+                        def get(self) -> float:
+                            return self.parent.values[self.k]
+
+                    return V(self.parent, self.k)
+
+            return _Wrapper(self, key)
+
+
+class AbstractUsageBackend(Protocol):
+    """Interface for usage event sinks."""
+
+    async def record(self, **evt) -> None:
+        """Persist a single usage event."""
+        ...
+
+
+class NullUsageBackend:
+    """No-op usage backend."""
+
+    async def record(self, **evt) -> None:  # pragma: no cover - trivial
+        return
+
+
+class PrometheusUsageBackend:
+    """Expose a Prometheus counter for token usage."""
+
+    def __init__(self) -> None:
+        if Counter is None:  # pragma: no cover - missing lib
+            raise RuntimeError("prometheus_client is required for this backend")
+        self.counter = Counter(
+            "attach_usage_tokens_total",
+            "Total tokens processed by Attach Gateway",
+            ["user", "direction", "model"],
+        )
+
+    async def record(self, **evt) -> None:
+        user = evt.get("user", "unknown")
+        model = evt.get("model", "unknown")
+        tokens_in = int(evt.get("tokens_in", 0) or 0)
+        tokens_out = int(evt.get("tokens_out", 0) or 0)
+        self.counter.labels(user=user, direction="in", model=model).inc(tokens_in)
+        self.counter.labels(user=user, direction="out", model=model).inc(tokens_out)
+
+
+class OpenMeterBackend:
+    """Stub for future OpenMeter integration."""
+
+    async def record(self, **evt) -> None:  # pragma: no cover - not implemented
+        raise NotImplementedError

--- a/usage/factory.py
+++ b/usage/factory.py
@@ -2,12 +2,28 @@ from __future__ import annotations
 
 """Factory for usage backends."""
 
+import os
+import warnings
+
 from .backends import (
     AbstractUsageBackend,
     NullUsageBackend,
     OpenMeterBackend,
     PrometheusUsageBackend,
 )
+
+
+def _select_backend() -> str:
+    """Return backend name from env vars with deprecation warning."""
+    if "USAGE_METERING" in os.environ:
+        return os.getenv("USAGE_METERING", "null")
+    if "USAGE_BACKEND" in os.environ:
+        warnings.warn(
+            "USAGE_BACKEND is deprecated; rename to USAGE_METERING",
+            UserWarning,
+            stacklevel=2,
+        )
+    return os.getenv("USAGE_BACKEND", "null")
 
 
 def get_usage_backend(kind: str) -> AbstractUsageBackend:
@@ -19,5 +35,8 @@ def get_usage_backend(kind: str) -> AbstractUsageBackend:
         except Exception:
             return NullUsageBackend()
     if kind == "openmeter":
-        return OpenMeterBackend()
+        try:
+            return OpenMeterBackend()
+        except Exception:
+            return NullUsageBackend()
     return NullUsageBackend()

--- a/usage/factory.py
+++ b/usage/factory.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Factory for usage backends."""
+
+from .backends import (
+    AbstractUsageBackend,
+    NullUsageBackend,
+    OpenMeterBackend,
+    PrometheusUsageBackend,
+)
+
+
+def get_usage_backend(kind: str) -> AbstractUsageBackend:
+    """Return an instance of the requested usage backend."""
+    kind = (kind or "null").lower()
+    if kind == "prometheus":
+        try:
+            return PrometheusUsageBackend()
+        except Exception:
+            return NullUsageBackend()
+    if kind == "openmeter":
+        return OpenMeterBackend()
+    return NullUsageBackend()

--- a/usage/metrics.py
+++ b/usage/metrics.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Utilities for exposing Attach Gateway usage metrics."""
+
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse, Response
+
+
+def mount_metrics(app: FastAPI) -> None:
+    """Attach a Prometheus-compatible ``/metrics`` route to ``app``."""
+
+    @app.get("/metrics", include_in_schema=False)
+    async def metrics() -> Response:  # noqa: D401
+        usage = getattr(app.state, "usage", None)
+        if usage is None:
+            return PlainTextResponse("# No usage backend configured\n")
+        try:
+            from prometheus_client import CONTENT_TYPE_LATEST, REGISTRY, generate_latest
+        except ImportError:
+            counter = getattr(usage, "counter", None)
+            if counter is None or not hasattr(counter, "values"):
+                return PlainTextResponse("# No metrics available\n")
+            lines = [
+                "# HELP attach_usage_tokens_total Total tokens processed by Attach Gateway",
+                "# TYPE attach_usage_tokens_total counter",
+            ]
+            for (u, d, m), v in counter.values.items():
+                lines.append(
+                    f'attach_usage_tokens_total{{user="{u}",direction="{d}",model="{m}"}} {v}'
+                )
+            return PlainTextResponse("\n".join(lines) + "\n")
+        else:
+            if not hasattr(usage, "counter"):
+                return PlainTextResponse("# No usage counter\n")
+            return PlainTextResponse(
+                generate_latest(REGISTRY), media_type=CONTENT_TYPE_LATEST
+            )

--- a/utils/env.py
+++ b/utils/env.py
@@ -1,0 +1,25 @@
+"""Env helpers used across entry-points."""
+
+import logging
+import os
+
+log = logging.getLogger(__name__)
+
+
+def int_env(var: str, default: int | None = None) -> int | None:
+    """Read $VAR as positive int.
+    • '', 'null', 'none', 'false', 'infinite'  -> None
+    • invalid / non-positive -> default
+    """
+    val = os.getenv(var)
+    if val is None:
+        return default
+    val = val.strip().lower()
+    if val in {"", "null", "none", "false", "infinite"}:
+        return None
+    try:
+        num = int(val)
+        return num if num > 0 else default
+    except ValueError:
+        log.warning("⚠️  %s=%s is not a valid int; using default=%s", var, val, default)
+        return default


### PR DESCRIPTION
@Hashamulhaq could you review when you have a chance? In particular:
Scope of the patch

- Full rewrite of middleware/quota.py
- Uses a sliding-window meter store (InMemoryMeterStore + RedisMeterStore)
- Streaming-aware quota enforcement via the internal _Streamer helper
- Robust tail-parsing in finalize() for:
	SSE frames (data: ...)
	[DONE] sentinels
	plain JSON bodies
- Prometheus usage counters are now updated once with the canonical numbers taken from the LLM response.
