### PR TITLE
Handle quota breach mid-stream

### DIFF
--- a/tests/test_token_quota_middleware.py
+++ b/tests/test_token_quota_middleware.py
@@ -67,9 +67,8 @@ async def test_midstream_over_limit_rolls_back(monkeypatch):
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         resp = await client.get("/stream", headers=headers)
-        text = resp.text
 
-    assert resp.status_code == 200
-    assert text == "hi"
+    assert resp.status_code == 429
+    assert resp.json()["detail"] == "token quota exceeded"
     total = await store.peek_total("carol")
     assert total == 2


### PR DESCRIPTION
## Summary
- return JSON error with status 429 if token quota is exceeded during streaming
- buffer streaming responses so status can be changed before sending
- test expectation updated for mid-stream quota breach

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eeebdc10c832b9ce2a2a42b430813