### PR TITLE
Add redis cache and queue

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+"""API auxiliary routers."""

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+"""Expose gateway metrics."""
+
+from fastapi import APIRouter, Request
+
+router = APIRouter()
+
+
+@router.get("/v1/metrics")
+async def metrics(request: Request) -> dict[str, int]:
+    """Return cached metrics from Redis if available."""
+
+    cache = getattr(request.app.state, "cache", None)
+    client = getattr(cache, "_client", None)
+    if client is None:
+        return {"cache_hits": 0, "jobs_processed": 0}
+    try:
+        hits = int(client.get("metrics:cache_hits") or 0)
+        jobs = int(client.get("metrics:jobs_processed") or 0)
+    except Exception:
+        hits = jobs = 0
+    return {"cache_hits": hits, "jobs_processed": jobs}

--- a/attach/cache.py
+++ b/attach/cache.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+"""Simple runtime-swappable cache implementations."""
+
+import hashlib
+import json
+from typing import Any, Optional
+
+import redis
+
+
+class _MemoryCache:
+    """In-memory dictionary cache."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, Any] = {}
+
+    def get(self, key: str) -> Any | None:
+        return self._data.get(key)
+
+    def set(self, key: str, value: Any) -> None:
+        self._data[key] = value
+
+
+class _RedisCache:
+    """Redis-backed cache."""
+
+    def __init__(self, url: str) -> None:
+        self._client = redis.Redis.from_url(url)
+
+    def get(self, key: str) -> Any | None:
+        val = self._client.get(key)
+        if val is None:
+            return None
+        try:
+            return json.loads(val)
+        except Exception:
+            return None
+
+    def set(self, key: str, value: Any) -> None:
+        self._client.set(key, json.dumps(value))
+
+
+def build_cache(kind: str = "memory", redis_url: Optional[str] = None) -> Any:
+    """Return a cache instance for ``kind``."""
+
+    kind = (kind or "memory").lower()
+    if kind == "redis":
+        url = redis_url or "redis://localhost:6379/0"
+        return _RedisCache(url)
+    return _MemoryCache()
+
+
+def cache_key(model: str, messages: str, params: dict) -> str:
+    """Compute a deterministic cache key."""
+
+    blob = model + messages + json.dumps(params, sort_keys=True)
+    return hashlib.sha256(blob.encode()).hexdigest()

--- a/attach/queue.py
+++ b/attach/queue.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+"""Simple runtime-swappable FIFO job queue."""
+
+import asyncio
+import json
+import uuid
+from typing import Any, Optional
+
+import redis
+
+
+class _MemoryQueue:
+    """Asyncio-based in-memory queue."""
+
+    def __init__(self) -> None:
+        self._q: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+
+    async def put(self, job: dict[str, Any]) -> None:
+        await self._q.put(job)
+
+    async def get(self) -> dict[str, Any]:
+        job = await self._q.get()
+        self._q.task_done()
+        return job
+
+
+class _RedisQueue:
+    """Redis-backed job queue."""
+
+    def __init__(self, url: str, name: str = "attach:queue") -> None:
+        self._client = redis.Redis.from_url(url)
+        self._name = name
+
+    async def put(self, job: dict[str, Any]) -> None:
+        loop = asyncio.get_running_loop()
+        data = json.dumps(job)
+        await loop.run_in_executor(None, self._client.lpush, self._name, data)
+
+    async def get(self) -> dict[str, Any]:
+        loop = asyncio.get_running_loop()
+        key, data = await loop.run_in_executor(None, self._client.brpop, self._name, 0)
+        return json.loads(data)
+
+
+def build_queue(kind: str = "memory", redis_url: Optional[str] = None) -> Any:
+    """Return a queue instance for ``kind``."""
+
+    kind = (kind or "memory").lower()
+    if kind == "redis":
+        url = redis_url or "redis://localhost:6379/0"
+        return _RedisQueue(url)
+    return _MemoryQueue()
+
+
+def new_job(payload: dict[str, Any]) -> dict[str, Any]:
+    """Create a new job dictionary with a unique ID."""
+
+    job = {"id": uuid.uuid4().hex}
+    job.update(payload)
+    return job

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3'
+services:
+  gateway:
+    build: .
+    environment:
+      - QUEUE_BACKEND=redis
+      - CACHE_BACKEND=redis
+      - REDIS_URL=redis://redis:6379/0
+    ports:
+      - "8080:8080"
+  worker:
+    build: .
+    command: python scripts/worker.py
+    environment:
+      - QUEUE_BACKEND=redis
+      - CACHE_BACKEND=redis
+      - REDIS_URL=redis://redis:6379/0
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ pytest-asyncio>=0.23.0
 
 # Memory Backend (Optional)
 weaviate-client>=3.26.7,<4.0.0
+redis[hiredis]>=5.0.0
 
 # Development Tools
 black>=24.1.0

--- a/scripts/worker.py
+++ b/scripts/worker.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Background worker that processes queued chat requests."""
+
+import asyncio
+import json
+import os
+
+import httpx
+
+from attach.cache import build_cache, cache_key
+from attach.queue import build_queue
+
+ENGINE_URL = os.getenv("ENGINE_URL", "http://localhost:11434").rstrip("/")
+CACHE_BACKEND = os.getenv("CACHE_BACKEND", "memory")
+QUEUE_BACKEND = os.getenv("QUEUE_BACKEND", "redis")
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+
+cache = build_cache(CACHE_BACKEND, REDIS_URL)
+queue = build_queue(QUEUE_BACKEND, REDIS_URL)
+
+
+async def main() -> None:
+    async with httpx.AsyncClient(timeout=None) as client:
+        while True:
+            job = await queue.get()
+            req = job.get("request", {})
+            headers = job.get("headers", {})
+            key = cache_key(
+                req.get("model", ""),
+                json.dumps(req.get("messages", [])),
+                req.get("params", {}),
+            )
+            try:
+                resp = await client.post(
+                    f"{ENGINE_URL}/v1/chat/completions",
+                    json=req,
+                    headers=headers,
+                    timeout=None,
+                )
+                result = resp.json()
+                cache.set(key, result)
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add redis-backed cache and queue modules
- implement basic worker script
- expose /v1/metrics API router
- wire cache/queue/metrics into gateway configuration
- cache or queue chat requests in engine
- add redis dependency and docker-compose example

## Testing
- `pytest -q` *(fails: tiktoken tries to download encoding)*

------
https://chatgpt.com/codex/tasks/task_e_6889c8839738832babafaa92dcbd1f47